### PR TITLE
feat: お問い合わせ確認ページの実装 #9

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Http\Requests\StoreContactRequest;
 use App\Models\Category;
 use App\Models\Tag;
 
@@ -14,5 +15,26 @@ class ContactController extends Controller
         $tags = Tag::all();
 
         return view('contact.index', compact('categories', 'tags'));
+    }
+
+    public function confirm(StoreContactRequest $request)
+    {
+        // バリデーション済みデータ
+        $validated = $request->validated();
+
+        // カテゴリ名取得
+        $category = Category::find($validated['category_id']);
+
+        // タグ名取得（複数）
+        $tags = collect();
+        if (!empty($validated['tag_ids'])) {
+            $tags = Tag::whereIn('id', $validated['tag_ids'])->get();
+        }
+
+        return view('contact.confirm', [
+            'validated' => $validated,
+            'category' => $category,
+            'tags' => $tags,
+        ]);
     }
 }

--- a/app/Http/Requests/StoreContactRequest.php
+++ b/app/Http/Requests/StoreContactRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreContactRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'last_name' => ['required', 'string', 'max:255'],
+            'first_name' => ['required', 'string', 'max:255'],
+            'gender' => ['required', 'integer', 'in:1,2,3'],
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'tel' => ['required', 'string', 'regex:/^[0-9]{10,11}$/'],
+            'address' => ['required', 'string', 'max:255'],
+            'building' => ['nullable', 'string', 'max:255'],
+            'category_id' => ['required', 'integer', 'exists:categories,id'],
+            'detail' => ['required', 'string', 'max:120'],
+            'tag_ids' => ['nullable', 'array'],
+            'tag_ids.*' => ['integer'],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'last_name.required' => '姓を入力してください',
+            'first_name.required' => '名を入力してください',
+            'gender.required' => '性別を選択してください',
+
+            'email.required' => 'メールアドレスを入力してください',
+            'email.email' => 'メールアドレスはメール形式で入力してください',
+
+            'tel.required' => '電話番号を入力してください',
+            //要件に無いが必要かと思い追加
+            'tel.regex' => '電話番号は10桁または11桁の数字で入力してください',
+
+            'address.required' => '住所を入力してください',
+
+            'category_id.required' => 'お問い合わせの種類を選択してください',
+
+            'detail.required' => 'お問い合わせの内容を入力してください',
+            'detail.max' => 'お問い合わせの内容は120文字以内で入力してください',
+        ];
+    }
+
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,3 +15,4 @@ use App\Http\Controllers\ContactController;
 */
 
 Route::get('/', [ContactController::class, 'index'])->name('contact.index');
+Route::post('/contacts/confirm', [ContactController::class, 'confirm'])->name('contact.confirm');


### PR DESCRIPTION
## 概要
お問い合わせフォームの **確認ページ** を実装しました。  
本 Issue は「確認ページまで」が対象であり、**保存処理（POST /contacts → DB 保存）は次の Issue（#3）で実装します**。

フロント側（Blade）は既に実装済みのため、バックエンド側のバリデーションと確認ページ表示処理のみ対応しています。

---

## 対応内容

### 1. バリデーション（StoreContactRequest）
以下の項目について要件通りのバリデーションを実装しました。

- 姓：必須 / string / max:255  
- 名：必須 / string / max:255  
- 性別：必須 / integer / in:1,2,3  
- メールアドレス：必須 / string / email / max:255  
- 電話番号：必須 / string / regex:/^[0-9]{10,11}$/  
- 住所：必須 / string / max:255  
- 建物名：nullable / string / max:255  
- カテゴリ：必須 / integer / exists:categories,id  
- お問い合わせ内容：必須 / string / max:120  
- タグ：nullable / array（※ exists チェックは 次Issue で実装）

### 2. 確認ページ表示（ContactController@confirm）
- バリデーション済みデータを取得
- カテゴリ名を Category モデルから取得
- タグ名を Tag モデルから取得
- Blade が必要とする以下の変数を渡す  
  - `$validated`  
  - `$category`  
  - `$tags`  

### 3. 修正ボタン・送信ボタン
- 修正ボタン：history.back() により入力画面へ戻る（フロント側実装済み）
- 送信ボタン：POST `/contacts` に送信される  
  ※ **保存処理は次 Issueで実装**

---

## 動作確認
- バリデーションが要件通り動作する  
- バリデーションエラー時に入力画面へ戻る  
- 確認ページに入力内容が正しく表示される  
- 性別・カテゴリ・タグが文字列で表示される  
- hidden input により入力値が保持される  
- 送信ボタンが POST `/contacts` に送信される（保存処理は未実装）

---

## 備考
- 保存処理（contacts/contact_tag への保存、/thanks へのリダイレクト）は **次Issue** で対応します。

## 対応 Issue
close #9