### PR TITLE
feat: タグ編集ページを実装 #17

### DIFF
--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Tag;
 use App\Http\Requests\StoreTagRequest;
+use App\Http\Requests\UpdateTagRequest;
 
 class TagController extends Controller
 {
@@ -20,5 +21,14 @@ class TagController extends Controller
     public function edit(Tag $tag)
     {
         return view('admin.tags.edit', compact('tag'));
+    }
+
+    public function update(UpdateTagRequest $request, Tag $tag)
+    {
+        $tag->update([
+            'name' => $request->name,
+        ]);
+
+        return redirect('/admin')->with('success', 'タグを更新しました');
     }
 }

--- a/app/Http/Requests/UpdateTagRequest.php
+++ b/app/Http/Requests/UpdateTagRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateTagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:50',
+                Rule::unique('tags')->ignore($this->tag),
+            ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'タグ名を入力してください',
+            'name.max' => 'タグ名は50文字以内で入力してください',
+            'name.unique' => 'そのタグ名は既に使用されています',
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,10 +24,13 @@ Route::post('/contacts', [ContactController::class, 'store']);
 Route::get('/thanks', [ContactController::class, 'thanks']);
 
 Route::post('/register', [RegisterController::class, 'store'])->middleware('guest');
+
 Route::middleware('auth')->group(function () {
     Route::get('/admin', [AdminController::class, 'index']);
     Route::get('/admin/contacts/{contact}', [AdminController::class, 'show']);
 
     Route::post('/admin/tags', [TagController::class, 'store']);
-    Route::get('/admin/tags/{tag}/edit', [TagController::class, 'edit']);
+
+    Route::get('/admin/tags/{tag}/edit', [TagController::class, 'edit'])->name('tags.edit');
+    Route::put('/admin/tags/{tag}', [TagController::class, 'update'])->name('tags.update');
 });


### PR DESCRIPTION
### 概要
管理画面の **タグ編集ページ（GET /admin/tags/{tag}/edit）** と  
**タグ更新処理（PUT /admin/tags/{tag}）** を実装しました。

本 PR では以下の内容を中心に対応しています。

- タグ編集ページの表示
- タグ名の更新処理
- バリデーション（必須・50文字以内・ユニーク）
- エラーメッセージ表示
- 更新後のリダイレクト処理

---

## 実装内容

### 1. タグ編集ページの表示（GET /admin/tags/{tag}/edit）
- ルート：`GET /admin/tags/{tag}/edit`
- コントローラ：`TagController@edit`
- Blade：`resources/views/admin/tags/edit.blade.php`
- 現在のタグ名がフォームに入力された状態で表示されるように実装

---

### 2. タグ更新処理（PUT /admin/tags/{tag}）
- ルート：`PUT /admin/tags/{tag}`
- コントローラ：`TagController@update`
- リクエストクラス：`UpdateTagRequest`

#### バリデーション要件
- `name`：必須
- 50文字以内
- ユニーク（ただし **自身の現在の名前は許可**）

#### エラーメッセージ
- 未入力：`タグ名を入力してください`
- 50文字超過：`タグ名は50文字以内で入力してください`
- 重複：`そのタグ名は既に使用されています`

#### 成功時
- タグ名が更新される
- `/admin` にリダイレクト
- 一覧に更新内容が反映される

#### 失敗時
- 編集ページに戻り、フォーム下にエラーメッセージを表示

---

## 追加・変更したファイル

### 追加
- `app/Http/Requests/UpdateTagRequest.php`  
  - タグ更新用バリデーションを実装

### 変更
- `routes/web.php`  
  - タグ編集・更新ルートを追加（重複ルートを整理）

- `app/Http/Controllers/TagController.php`  
  - edit / update メソッドを実装

- `resources/views/admin/tags/edit.blade.php`  
  - タグ編集フォームを実装（エラーメッセージ対応）

---

## 動作確認

- `GET /admin/tags/{tag}/edit` で編集ページが表示される  
- 現在のタグ名がフォームに表示される  
- 正しい入力でタグ名が更新され `/admin` にリダイレクトされる  
- 未入力・50文字超過・重複時にバリデーションエラーが表示される  
- エラーメッセージがフォーム下に赤文字で表示される  

---

## 備考
- Blade は提供済みのため UI 実装は最小限  
- タグ削除機能は別 Issue にて対応予定  
- CSV エクスポート機能も別 Issue で対応予定  

---

## 対応 Issue
close #17