### PR TITLE
feat: タグ削除機能を実装 #21

### DIFF
--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -31,4 +31,11 @@ class TagController extends Controller
 
         return redirect('/admin')->with('success', 'タグを更新しました');
     }
+
+    public function destroy(Tag $tag)
+    {
+        $tag->delete();
+
+        return redirect('/admin')->with('success', 'タグを削除しました');
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,4 +33,5 @@ Route::middleware('auth')->group(function () {
 
     Route::get('/admin/tags/{tag}/edit', [TagController::class, 'edit'])->name('tags.edit');
     Route::put('/admin/tags/{tag}', [TagController::class, 'update'])->name('tags.update');
+    Route::delete('/admin/tags/{tag}', [TagController::class, 'destroy'])->name('tags.destroy');
 });


### PR DESCRIPTION
### 概要
管理画面の **タグ削除機能（DELETE /admin/tags/{tag}）** を実装しました。

フロント側（Blade）の削除ボタンは既に実装済みのため、  
本 PR では **バックエンド側の削除処理のみ** を対応しています。

---

## 実装内容

### 1. タグ削除処理（DELETE /admin/tags/{tag}）
- ルート：`DELETE /admin/tags/{tag}`
- コントローラ：`TagController@destroy`

#### 削除時の挙動
- 対象タグを `tags` テーブルから削除
- `contact_tag` の関連レコードは外部キー制約（ON DELETE CASCADE）により自動削除
- 削除後 `/admin` にリダイレクト

---

## 変更したファイル

### 追加
- なし（フロント側は既存）

### 変更
- `routes/web.php`  
  - タグ削除ルートを追加

- `app/Http/Controllers/TagController.php`  
  - destroy メソッドを実装

---

## 動作確認

- 管理画面一覧の削除ボタンから DELETE リクエストが送信される  
- タグが正常に削除される  
- `contact_tag` の関連レコードも自動で削除される  
- `/admin` にリダイレクトされる  
- 存在しないタグ ID を指定した場合、404 が返る（Laravel の暗黙的バインディング）

---

## 備考
- 外部キー制約（ON DELETE CASCADE）が前提  
- バリデーションは不要（入力項目なし）  
- タグ編集機能とは別 Issue  

---

## 対応 Issue
close #21
