### PR TITLE
feat: お問い合わせ削除機能を実装 #23

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -55,4 +55,10 @@ class AdminController extends Controller
         $contact->load(['category', 'tags']);
         return view('admin.show', compact('contact'));
     }
+    public function destroy(Contact $contact)
+    {
+        $contact->delete(); // contact_tag は外部キーで自動削除
+
+        return redirect('/admin')->with('success', 'お問い合わせを削除しました');
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ Route::post('/register', [RegisterController::class, 'store'])->middleware('gues
 Route::middleware('auth')->group(function () {
     Route::get('/admin', [AdminController::class, 'index']);
     Route::get('/admin/contacts/{contact}', [AdminController::class, 'show']);
+    Route::delete('/admin/contacts/{contact}', [AdminController::class, 'destroy'])->name('contacts.destroy');
 
     Route::post('/admin/tags', [TagController::class, 'store']);
 


### PR DESCRIPTION
### 概要
お問い合わせ詳細ページの **削除機能（DELETE /admin/contacts/{contact}）** を実装しました。

詳細ページの表示および「一覧に戻る」ボタンは既に要件どおり動作しているため、  
本 PR では **削除処理のみ** を実装しています。

---

## 実装内容

### 1. お問い合わせ削除処理（DELETE /admin/contacts/{contact}）
- ルート：`DELETE /admin/contacts/{contact}`
- コントローラ：`AdminController@destroy`

#### 削除時の挙動
- 対象のお問い合わせデータを `contacts` テーブルから削除
- `contact_tag` の関連レコードは外部キー制約（ON DELETE CASCADE）により自動削除
- 削除後 `/admin` にリダイレクト

---

## 変更したファイル

### 変更
- `routes/web.php`  
  - お問い合わせ削除ルートを追加

- `app/Http/Controllers/AdminController.php`  
  - destroy メソッドを実装

---

## 動作確認

- 詳細ページの削除ボタンから DELETE リクエストが送信される  
- 対象のお問い合わせデータが削除される  
- `contact_tag` の関連レコードも自動で削除される  
- `/admin` にリダイレクトされる  
- 存在しない ID を指定した場合は 404（Laravel の暗黙的バインディング）

---

## 備考
- フロント側（Blade）は既に削除ボタンがあるため変更なし  
- バリデーションは不要（入力項目なし）  
- 一覧ページの検索・表示機能とは独立した Issue  

---

## 対応 Issue
close #23
