### PR TITLE
feat: APIお問い合わせ一覧取得機能の実装 #27

### DIFF
--- a/app/Http/Controllers/Api/V1/ContactController.php
+++ b/app/Http/Controllers/Api/V1/ContactController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Http\Requests\Api\V1\IndexContactRequest;
+use App\Http\Resources\ContactResource;
+use App\Models\Contact;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ContactController extends Controller
+{
+    public function index(IndexContactRequest $request): AnonymousResourceCollection
+    {
+        $validated = $request->validated();
+
+        $query = Contact::with(['category', 'tags']);
+
+        if (!empty($validated['keyword'])) {
+            $keyword = $validated['keyword'];
+            $query->where(function ($q) use ($keyword) {
+                $q->where('first_name', 'like', "%{$keyword}%")
+                    ->orWhere('last_name', 'like', "%{$keyword}%")
+                    ->orWhere('email', 'like', "%{$keyword}%");
+            });
+        }
+
+        if (!empty($validated['gender'])) {
+            $query->where('gender', $validated['gender']);
+        }
+
+        if (!empty($validated['category_id'])) {
+            $query->where('category_id', $validated['category_id']);
+        }
+
+        if (!empty($validated['date'])) {
+            $query->whereDate('created_at', $validated['date']);
+        }
+
+        $perPage = $validated['per_page'] ?? 20;
+
+        $contacts = $query->latest()->paginate($perPage);
+
+        return ContactResource::collection($contacts);
+    }
+}

--- a/app/Http/Requests/Api/V1/IndexContactRequest.php
+++ b/app/Http/Requests/Api/V1/IndexContactRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexContactRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'keyword' => ['nullable', 'string', 'max:255'],
+            'gender' => ['nullable', 'integer', 'in:1,2,3'], // API は 1,2,3 のみ
+            'category_id' => ['nullable', 'integer', 'exists:categories,id'],
+            'date' => ['nullable', 'date'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'gender.in' => '性別の値が不正です',
+            'category_id.exists' => '選択されたカテゴリーが存在しません',
+            'date.date' => '日付の形式が不正です',
+        ];
+    }
+}

--- a/app/Http/Resources/ContactResource.php
+++ b/app/Http/Resources/ContactResource.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ContactResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'first_name' => $this->first_name,
+            'last_name' => $this->last_name,
+            'gender' => $this->gender,
+            'email' => $this->email,
+            'tel' => $this->tel,
+            'address' => $this->address,
+            'building' => $this->building,
+            'category' => [
+                'id' => $this->category->id,
+                'content' => $this->category->content,
+            ],
+            'tags' => $this->tags->map(function ($tag) {
+                return [
+                    'id' => $tag->id,
+                    'name' => $tag->name,
+                ];
+            }),
+            'created_at' => $this->created_at->toIso8601String(),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\V1\ContactController;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,4 +17,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
+});
+Route::prefix('v1')->group(function () {
+    Route::apiResource('contacts', ContactController::class)->only(['index']);
 });


### PR DESCRIPTION
## 概要
公開 API として、お問い合わせ一覧を取得するエンドポイント  
**GET /api/v1/contacts** を実装しました。

検索条件（keyword / gender / category_id / date）と  
ページネーション（page / per_page）に対応し、  
JSON 形式で `data` 配列と `meta` 情報を返します。

---

## 変更内容

### 1. ルーティングの追加
教材方針に合わせ、`prefix('v1')` を使用してバージョニングを管理。

```php
Route::prefix('v1')->group(function () {
    Route::apiResource('contacts', ContactController::class)->only(['index']);
});
```

## 2. IndexContactRequest の作成
- API 用のバリデーションルールを実装  
- Web 版と異なる gender / per_page の仕様に対応  
- keyword / gender / category_id / date / page / per_page を検証  

## 3. ContactController@index の実装
- `Contact::with(['category', 'tags'])` による Eager Loading  
- 検索条件（keyword / gender / category_id / date）の適用  
- `latest()->paginate($perPage)` によるページネーション  
- `ContactResource::collection()` によるレスポンス整形  
- 戻り値の型宣言として `AnonymousResourceCollection` を使用（教材スタイル）  

## 4. ContactResource の実装
- 一覧 API 用に必要な項目のみ返却  
- category / tags のネストは詳細 API のみで使用するため一覧では省略  

---

## 動作確認
- GET /api/v1/contacts が正しい JSON を返す  
- keyword / gender / category_id / date の検索が正しく動作する  
- ページネーション（page / per_page）が正しく動作する  
- バリデーションエラー時に 422 + 日本語エラーメッセージが返る  
- ContactResource::collection() 形式で返却される  
- 認証不要でアクセスできる  

## 対応 Issue
close #27