### PR TITLE
feat: API お問い合わせ詳細取得機能の実装 #29

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,28 +3,34 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Throwable;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler
 {
-    /**
-     * The list of the inputs that are never flashed to the session on validation exceptions.
-     *
-     * @var array<int, string>
-     */
     protected $dontFlash = [
         'current_password',
         'password',
         'password_confirmation',
     ];
 
-    /**
-     * Register the exception handling callbacks for the application.
-     */
     public function register(): void
     {
-        $this->reportable(function (Throwable $e) {
-            //
+        $this->renderable(function (NotFoundHttpException $e, $request) {
+            if ($request->is('api/*')) {
+                return response()->json([
+                    'error' => 'お問い合わせが見つかりませんでした。',
+                ], 404);
+            }
+        });
+
+        $this->renderable(function (ModelNotFoundException $e, $request) {
+            if ($request->is('api/*')) {
+                return response()->json([
+                    'error' => 'お問い合わせが見つかりませんでした。',
+                ], 404);
+            }
         });
     }
 }

--- a/app/Http/Controllers/Api/V1/ContactController.php
+++ b/app/Http/Controllers/Api/V1/ContactController.php
@@ -15,7 +15,7 @@ class ContactController extends Controller
     {
         $validated = $request->validated();
 
-        $query = Contact::with(['category', 'tags']);
+        $query = Contact::query();
 
         if (!empty($validated['keyword'])) {
             $keyword = $validated['keyword'];
@@ -43,5 +43,12 @@ class ContactController extends Controller
         $contacts = $query->latest()->paginate($perPage);
 
         return ContactResource::collection($contacts);
+    }
+
+    public function show(Contact $contact): ContactResource
+    {
+        $contact->load(['category', 'tags']);
+
+        return new ContactResource($contact);
     }
 }

--- a/app/Http/Resources/ContactResource.php
+++ b/app/Http/Resources/ContactResource.php
@@ -23,17 +23,28 @@ class ContactResource extends JsonResource
             'tel' => $this->tel,
             'address' => $this->address,
             'building' => $this->building,
-            'category' => [
-                'id' => $this->category->id,
-                'content' => $this->category->content,
-            ],
-            'tags' => $this->tags->map(function ($tag) {
+            'detail' => $this->detail,
+
+            // 一覧では null、詳細では category が返る
+            'category' => $this->whenLoaded('category', function () {
                 return [
-                    'id' => $tag->id,
-                    'name' => $tag->name,
+                    'id' => $this->category->id,
+                    'content' => $this->category->content,
                 ];
             }),
+
+            // 一覧では空配列、詳細では tags が返る
+            'tags' => $this->whenLoaded('tags', function () {
+                return $this->tags->map(function ($tag) {
+                    return [
+                        'id' => $tag->id,
+                        'name' => $tag->name,
+                    ];
+                });
+            }),
+
             'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,5 +19,5 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 Route::prefix('v1')->group(function () {
-    Route::apiResource('contacts', ContactController::class)->only(['index']);
+    Route::apiResource('contacts', ContactController::class)->only(['index', 'show']);
 });


### PR DESCRIPTION
## 概要
公開 API として、お問い合わせ詳細を取得するエンドポイント  
**GET /api/v1/contacts/{contact}** を実装しました。

カテゴリ（category）とタグ（tags）をネストした JSON を返却し、  
存在しない ID の場合は 404 を返すようにしています。

---

## 変更内容

### 1. ルーティング追加
- `/api/v1/contacts/{contact}` を `show` のみ許可する形で追加
- `apiResource` の `only(['index', 'show'])` を使用

### 2. ContactController@show の実装
- ルートモデルバインディングで `Contact $contact` を取得
- `$contact->load(['category', 'tags'])` でリレーションを読み込み
- `ContactResource` で返却

### 3. ContactResource の拡張
- 詳細 API では category / tags をネストして返却
- 一覧 API では whenLoaded により返却されない

### 4. 404 エラーのカスタム対応
- 存在しない ID の場合、`ModelNotFoundException` / `NotFoundHttpException` をキャッチ
- 日本語メッセージで 404 を返却  
  `"お問い合わせが見つかりませんでした。"`

---

## 動作確認

- 指定 ID の Contact が取得できる
- category / tags がネストされた JSON で返却される
- 存在しない ID の場合、カスタム JSON を返却  
  `{"error": "お問い合わせが見つかりませんでした。"}`

---

## 備考
- 一覧 API と詳細 API は返却項目が異なる  
- 404 メッセージは日本語で統一  
- 今後、更新・削除 API を追加する際に `only()` を削除予定  

---

## 対応 Issue
close #29