### PR TITLE
feat: API お問い合わせ更新機能の実装 #33

### DIFF
--- a/app/Http/Controllers/Api/V1/ContactController.php
+++ b/app/Http/Controllers/Api/V1/ContactController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Http\Requests\Api\V1\IndexContactRequest;
 use App\Http\Requests\Api\V1\StoreContactRequest;
+use App\Http\Requests\Api\V1\UpdateContactRequest;
 use App\Http\Resources\ContactResource;
 use App\Models\Contact;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -70,6 +71,30 @@ class ContactController extends Controller
         return (new ContactResource($contact))
             ->response()
             ->setStatusCode(201);
+    }
+
+    public function update(UpdateContactRequest $request, string $id)
+    {
+        $contact = Contact::find($id);
+
+        if (!$contact) {
+            return response()->json([
+                'error' => 'お問い合わせが見つかりませんでした。'
+            ], 404);
+        }
+
+        $validated = $request->validated();
+
+        $tagIds = $validated['tag_ids'] ?? [];
+
+        $contact->update($validated);
+
+        // タグ同期（attach ではなく sync）
+        $contact->tags()->sync($tagIds);
+
+        $contact->load(['category', 'tags']);
+
+        return new ContactResource($contact);
     }
 
 }

--- a/app/Http/Requests/Api/V1/UpdateContactRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateContactRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateContactRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'first_name' => ['required', 'string', 'max:255'],
+            'last_name' => ['required', 'string', 'max:255'],
+            'gender' => ['required', 'integer', 'in:1,2,3'],
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'tel' => ['required', 'string', 'regex:/^[0-9]{10,11}$/'],
+            'address' => ['required', 'string', 'max:255'],
+            'building' => ['nullable', 'string', 'max:255'],
+            'category_id' => ['required', 'integer', 'exists:categories,id'],
+            'detail' => ['required', 'string', 'max:120'],
+            'tag_ids' => ['nullable', 'array'],
+            'tag_ids.*' => ['integer', 'exists:tags,id'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'first_name.required' => '姓を入力してください',
+            'last_name.required' => '名を入力してください',
+            'gender.required' => '性別を選択してください',
+            'email.required' => 'メールアドレスを入力してください',
+            'email.email' => 'メールアドレスはメール形式で入力してください',
+            'tel.required' => '電話番号を入力してください',
+            'tel.regex' => '電話番号はハイフンなしの10〜11桁で入力してください',
+            'gender.in' => '性別の値が不正です',
+            'category_id.exists' => '選択されたカテゴリーが存在しません',
+            'tag_ids.*.exists' => '選択されたタグが存在しません',
+            'address.required' => '住所を入力してください',
+            'category_id.required' => 'お問い合わせの種類を選択してください',
+            'detail.required' => 'お問い合わせの内容を入力してください',
+            'detail.max' => 'お問い合わせの内容は120文字以内で入力してください',
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,5 +19,5 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 Route::prefix('v1')->group(function () {
-    Route::apiResource('contacts', ContactController::class)->only(['index', 'show', 'store']);
+    Route::apiResource('contacts', ContactController::class)->only(['index', 'show', 'store', 'update']);
 });


### PR DESCRIPTION
## 概要
既存のお問い合わせ内容を更新する API エンドポイント  
PUT /api/v1/contacts/{contact} を実装しました。

更新成功時は 200 OK を返し、  
バリデーションエラー時は 422 Unprocessable Entity を返します。

Web版のバリデーションメッセージに加え、  
API 独自のエラーメッセージ（電話番号・性別・カテゴリ・タグ）にも対応しています。

---

## 変更内容

### 1. UpdateContactRequest の追加
- StoreContactRequest と同一のバリデーションルールを使用
- 以下の API 独自エラーメッセージを追加  
  - 電話番号：電話番号はハイフンなしの10〜11桁で入力してください  
  - 性別：性別の値が不正です  
  - カテゴリ：選択されたカテゴリーが存在しません  
  - タグ：選択されたタグが存在しません
- 日本語バリデーションメッセージに対応

### 2. ContactController@update の実装
- contact = Contact::find($id) により対象データを取得
- 存在しない場合は 404 JSON を返却  
    {
      "error": "お問い合わせが見つかりませんでした。"
    }
- validated = request->validated() による入力検証
- contact->update(validated) により更新処理
- tag_ids が存在する場合は contact->tags()->sync(tagIds) でタグを同期
- contact->load(['category', 'tags']) でリレーションを読み込み
- ContactResource で整形し 200 OK を返却

### 3. ContactResource の利用
- 詳細 APIと同じ構造で category / tags をネストして返却

---

## レスポンス仕様

### 200 OK（成功）
- 更新後の Contact の JSON を返却  
- 構造は 詳細API と同一

### 404 Not Found（ID が存在しない場合）
    {
      "error": "お問い合わせが見つかりませんでした。"
    }

### 422 Unprocessable Entity（バリデーションエラー）
- 作成 API（AP03）と同一構造  
- 日本語のエラーメッセージを返却

---

## 備考
- UpdateContactRequest は StoreContactRequest と同一ルール  
- locale=ja により日本語バリデーションが有効  
- タグは sync を使用し、既存の紐付けを置き換える  

---

## 対応 Issue
close #33   