### PR TITLE
feat: API お問い合わせ削除機能の実装 #35

### DIFF
--- a/app/Http/Controllers/Api/V1/ContactController.php
+++ b/app/Http/Controllers/Api/V1/ContactController.php
@@ -97,4 +97,16 @@ class ContactController extends Controller
         return new ContactResource($contact);
     }
 
+    public function destroy(Contact $contact)
+    {
+        if (!$contact) {
+            return response()->json([
+                'error' => 'お問い合わせが見つかりませんでした。'
+            ], 404);
+        }
+
+        $contact->delete();
+
+        return response()->json(null, 204);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,5 +19,5 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 Route::prefix('v1')->group(function () {
-    Route::apiResource('contacts', ContactController::class)->only(['index', 'show', 'store', 'update']);
+    Route::apiResource('contacts', ContactController::class);
 });


### PR DESCRIPTION
## 概要
既存のお問い合わせデータを削除する API を実装しました。  
指定 ID のお問い合わせと、紐付くタグ関連（中間テーブル）は外部キー制約により自動削除されます。

削除成功時は **204 No Content** を返し、  
ID が存在しない場合は **404 Not Found** を返します。

---

## 変更内容

### 1. ContactController@destroy の実装
- ルートモデルバインディングにより Contact $contact を取得
- 存在しない場合は 404 JSON を返却  
    {
      "error": "お問い合わせが見つかりませんでした。"
    }
- `$contact->delete()` により削除処理を実行
- 中間テーブル（contact_tag）は外部キーの cascade により自動削除
- `response()->json(null, 204)` を返却

---

## エンドポイント仕様

### DELETE /api/v1/contacts/{contact}
- 認証：不要
- 認可：不要
- コントローラ：Api\V1\ContactController@destroy

---

## リクエスト仕様

### パスパラメータ
- contact  
  - 型：integer  
  - 必須  
  - ルートモデルバインディングで Contact を取得  
  - 例：5

---

## レスポンス仕様

### 204 No Content（削除成功）
- レスポンスボディ：空

### 404 Not Found（ID が存在しない場合）
    {
      "error": "お問い合わせが見つかりませんでした。"
    }

---

## 備考
- ルートモデルバインディングにより Contact モデルを自動取得  
- 外部キー制約によりタグの紐付けは自動削除  
- レスポンスは空ボディの 204 を返却  

---

## 対応 Issue
close #35 