### PR TITLE
feat: お問い合わせ CSV エクスポート機能の実装 #37

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Http\Requests\StoreContactRequest;
+use App\Http\Requests\ExportContactRequest;
 use App\Models\Category;
 use App\Models\Tag;
 use App\Models\Contact;
@@ -68,5 +69,94 @@ class ContactController extends Controller
     public function thanks()
     {
         return view('contact.thanks');
+    }
+
+    public function export(ExportContactRequest $request)
+    {
+        $validated = $request->validated();
+
+        $query = Contact::query()->with('category');
+
+        // キーワード（名前 or メール）
+        if (!empty($validated['keyword'])) {
+            $keyword = $validated['keyword'];
+            $query->where(function ($q) use ($keyword) {
+                $q->where('first_name', 'like', "%{$keyword}%")
+                    ->orWhere('last_name', 'like', "%{$keyword}%")
+                    ->orWhere('email', 'like', "%{$keyword}%");
+            });
+        }
+
+        // 性別
+        if (!empty($validated['gender'])) {
+            $query->where('gender', $validated['gender']);
+        }
+
+        // カテゴリ
+        if (!empty($validated['category_id'])) {
+            $query->where('category_id', $validated['category_id']);
+        }
+
+        // 日付
+        if (!empty($validated['date'])) {
+            $query->whereDate('created_at', $validated['date']);
+        }
+
+        $contacts = $query->orderBy('created_at', 'desc')->get();
+
+        // CSV 出力
+        $headers = [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => 'attachment; filename="contacts.csv"',
+        ];
+
+        $callback = function () use ($contacts) {
+            $file = fopen('php://output', 'w');
+
+            // UTF-8 BOM
+            fwrite($file, "\xEF\xBB\xBF");
+
+            // ヘッダー行
+            fputcsv($file, [
+                'ID',
+                '氏名',
+                '性別',
+                'メール',
+                '電話',
+                '住所',
+                '建物',
+                'カテゴリ',
+                '内容',
+                '作成日時'
+            ]);
+
+            foreach ($contacts as $contact) {
+                fputcsv($file, [
+                    $contact->id,
+                    $contact->first_name . ' ' . $contact->last_name,
+                    $this->genderToString($contact->gender),
+                    $contact->email,
+                    $contact->tel,
+                    $contact->address,
+                    $contact->building,
+                    optional($contact->category)->content,
+                    $contact->detail,
+                    $contact->created_at->format('Y-m-d H:i:s'),
+                ]);
+            }
+
+            fclose($file);
+        };
+
+        return response()->stream($callback, 200, $headers);
+    }
+
+    private function genderToString($gender)
+    {
+        return [
+            1 => '男性',
+            2 => '女性',
+            3 => 'その他',
+        ][$gender] ?? '';
     }
 }

--- a/app/Http/Requests/ExportContactRequest.php
+++ b/app/Http/Requests/ExportContactRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ExportContactRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules()
+    {
+        return [
+            'keyword' => ['nullable', 'string', 'max:255'],
+            'gender' => ['nullable', 'integer', 'in:0,1,2,3'],
+            'category_id' => ['nullable', 'integer', 'exists:categories,id'],
+            'date' => ['nullable', 'date'],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'keyword.max' => 'キーワードは255文字以内で入力してください。',
+            'gender.in' => '性別の値が不正です。',
+            'category_id.exists' => '選択されたカテゴリーが存在しません。',
+            'date.date' => '日付の形式が不正です。',
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,3 +36,6 @@ Route::middleware('auth')->group(function () {
     Route::put('/admin/tags/{tag}', [TagController::class, 'update'])->name('tags.update');
     Route::delete('/admin/tags/{tag}', [TagController::class, 'destroy'])->name('tags.destroy');
 });
+
+//CSVエクスポート用認証不要
+Route::get('/contacts/export', [ContactController::class, 'export']);


### PR DESCRIPTION
## 概要
管理画面（一覧）で入力された検索条件をもとに、該当するお問い合わせデータを **BOM付き CSV** としてダウンロードできる機能を実装しました。

検索条件が未指定の場合は全件を **created_at の降順（新着順）** で取得します。

CSV の 1 行目にはヘッダー行を出力し、列順は以下の通りです：

1. ID  
2. 氏名（姓 + 名）  
3. 性別（文字列：男性 / 女性 / その他）  
4. メール  
5. 電話  
6. 住所  
7. 建物  
8. カテゴリ（文字列）  
9. 内容  
10. 作成日時（Y-m-d H:i:s）

※ 性別「0:未選択」はアプリ仕様上発生しないため、CSV では省略しています。

---

## 変更内容

### 1. ルーティングの追加
- 認証不要のため `/admin` グループ外に配置
- GET `/contacts/export` を追加

### 2. ExportContactRequest の作成
以下の検索条件に対してバリデーションを実装：

- keyword: nullable / string / max:255  
- gender: nullable / integer / in:0,1,2,3  
- category_id: nullable / integer / exists:categories,id  
- date: nullable / date  

### 3. ContactController@export の実装
- 管理画面と同じ検索ロジックを適用  
- フィルタ未指定時は全件を created_at desc で取得  
- BOM（UTF-8 BOM）を付与した CSV を StreamedResponse で返却  
- 性別は数値 → 文字列へ変換（1=男性、2=女性、3=その他）  
- カテゴリは category.content を出力  
- 作成日時は `Y-m-d H:i:s` 形式で出力  

---

## エンドポイント仕様

### GET /contacts/export
- 認証：不要  
- コントローラ：ContactController@export  
- バリデーション：ExportContactRequest  

---

## 検索条件（クエリパラメータ）

| パラメータ | 型 | 説明 |
|-----------|-----|------|
| keyword | string | 名前（部分一致）・メールアドレスに適用 |
| gender | integer | 1=男性、2=女性、3=その他 |
| category_id | integer | カテゴリID |
| date | date | created_at の日付で絞り込み |

---

## 挙動

### 1. 検索条件に一致するデータを取得
- 管理画面と同じ検索ロジックを使用  
- フィルタ未指定時は全件を created_at desc（新着順）で取得  

### 2. CSV を生成
- UTF-8 BOM を付与  
- 1 行目にヘッダー行  
- 2 行目以降にデータを出力  
- 性別は文字列に変換  
- カテゴリは category.content を出力  

### 3. ダウンロードレスポンスを返す
- Content-Type: text/csv  
- Content-Disposition: attachment; filename="contacts.csv"  

---

## 備考
- CSV 出力には Laravel の StreamedResponse を使用  
- 管理画面の検索ロジックと同じクエリビルダを利用  
- 性別「0:未選択」はアプリ仕様上発生しないため CSV では省略  
- タグは CSV に含めない（要件外） 

---

## 対応 Issue
close #37 