### PR TITLE
fix: README の Docker コマンド記述を修正する #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,24 @@ DB_PASSWORD=password
 
 ## 3. Composer パッケージのインストール
 
+```
 docker run --rm \
  -u "$(id -u):$(id -g)" \
  -v "$(pwd):/var/www/html" \
  -w /var/www/html \
  laravelsail/php82-composer:latest \
  composer install
+```
+
+※ 注意  
+以下の docker run コマンドは改行を含むため、行末の `\` も含めて正しくコピーしてください。  
+もしうまく動かない場合は、1 行版を使用してください。
+
+【1 行版】
+
+```
+docker run --rm -u "$(id -u):$(id -g)" -v "$(pwd):/var/www/html" -w /var/www/html laravelsail/php82-composer:latest composer install
+```
 
 ---
 


### PR DESCRIPTION
## README の Docker コマンド記述を修正しました

本 PR は以下の Issue に対応しています：

> README の環境構築手順に記載している Docker 経由の `composer install` コマンドが  
> 改行コピー時に崩れてエラーが発生する問題を修正する  
> Issue #49

---

## 対応内容

README の環境構築手順に記載されていた Docker コマンドが、  
改行を含む形式のまま掲載されていたため、コピー時に改行が崩れ、  
以下のようなエラーが発生する可能性がありました。

- `docker: 'docker run' requires at least 1 argument`
- `-u: command not found`
- `-v: command not found`

これは、行末の `\` が正しくコピーされず、コマンドが分割されてしまうことが原因です。

採点者や第三者が README の手順通りに環境構築できるよう、  
以下の修正を行いました。

---

## 修正内容

### 1. Docker コマンドをコードブロックに変更
- 改行版の Docker コマンドを ``` で囲み、コピーしやすい形式に修正しました。

### 2. 1 行版の Docker コマンドを README に追加
- 改行が崩れても問題なく実行できるよう、1 行版のコマンドを併記しました。

### 3. 手順の再現性を向上
- README の手順通りに実行すればエラーが発生しないように改善しました。

---

## 完了条件の達成状況

- README に 1 行版の Docker コマンドを追加  
- 改行版コマンドをコードブロックに変更  
- コピペ時にエラーが発生しないことを確認  
- PR が作成され、レビュー可能な状態になっている  

---

## 関連 Issue
- #45  
- #47  
- close #49
